### PR TITLE
Pre-launch polish for framework release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,5 @@ jobs:
         continue-on-error: true  # Don't fail on type errors (yet)
         
       - name: Run tests
-        run: pytest probablyprofit/tests/ -v --tb=short --timeout=30 --ignore=probablyprofit/tests/test_integration.py --ignore=probablyprofit/tests/test_backtest.py --ignore=probablyprofit/tests/test_agent_comprehensive.py --ignore=probablyprofit/tests/test_risk_comprehensive.py -k "not slow"
+        run: pytest probablyprofit/tests/ -v --tb=short -m "not slow"
         timeout-minutes: 5
-        continue-on-error: true  # Some tests are flaky in CI, tracked for fix

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,159 @@
+# Security Best Practices
+
+Guidelines for safely running ProbablyProfit in production.
+
+## Secrets Management
+
+### Never Commit Secrets
+- **NEVER** commit `.env` files to version control
+- The `.gitignore` already excludes `.env`, but double-check
+- If you accidentally commit a secret, rotate it immediately
+
+### Use Environment Variables
+Instead of passing secrets as command-line arguments:
+```bash
+# BAD - visible in process list
+python main.py --api-key sk-ant-123456
+
+# GOOD - use environment variables
+export ANTHROPIC_API_KEY=sk-ant-123456
+python main.py
+```
+
+### Secure Your .env File
+```bash
+# Set restrictive permissions
+chmod 600 .env
+
+# Verify
+ls -la .env
+# Should show: -rw------- (only owner can read/write)
+```
+
+## API Keys
+
+### Anthropic/OpenAI/Google
+- Create separate API keys for different environments (dev/staging/prod)
+- Set usage limits in the provider dashboard
+- Monitor usage for unexpected spikes
+- Rotate keys periodically (every 90 days recommended)
+
+### Polymarket Private Key
+This is your Polygon wallet private key. Handle with extreme care:
+- **NEVER** share it with anyone
+- Use a dedicated wallet for trading, not your main wallet
+- Only fund it with what you're willing to lose
+- Consider using a hardware wallet for large amounts
+
+## Production Deployment
+
+### Use a Secrets Manager
+For production deployments, consider:
+- AWS Secrets Manager
+- HashiCorp Vault
+- Google Secret Manager
+- Azure Key Vault
+
+Example with AWS:
+```python
+import boto3
+
+def get_secret(name):
+    client = boto3.client('secretsmanager')
+    response = client.get_secret_value(SecretId=name)
+    return response['SecretString']
+```
+
+### Docker Security
+If running in Docker:
+```yaml
+# docker-compose.yml
+services:
+  bot:
+    # Don't use root
+    user: "1000:1000"
+    # Read-only filesystem where possible
+    read_only: true
+    # Drop unnecessary capabilities
+    cap_drop:
+      - ALL
+    # Set resource limits
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+```
+
+### Network Security
+- Run behind a reverse proxy (nginx, Caddy)
+- Use HTTPS for all API endpoints
+- Restrict API access to trusted IPs
+- Use firewall rules to limit outbound connections
+
+## Logging and Monitoring
+
+### Redact Secrets from Logs
+ProbablyProfit automatically redacts common secret patterns, but:
+- Don't log full request/response bodies that might contain secrets
+- Review logs before sharing in bug reports
+- Use `logger.debug()` for sensitive data (disabled in production)
+
+### Audit Trail
+Keep records of:
+- All trades executed
+- Configuration changes
+- Emergency stop activations
+- Authentication events
+
+## Risk Controls
+
+### Use the Kill Switch
+The kill switch stops all trading immediately:
+```bash
+# Activate
+touch /tmp/probablyprofit.stop
+
+# Or via API
+curl -X POST http://localhost:8000/api/emergency-stop?reason=manual
+```
+
+### Set Conservative Limits
+Start with conservative risk limits:
+```bash
+MAX_POSITION_SIZE=50      # Small positions
+MAX_TOTAL_EXPOSURE=500    # Limited total exposure
+MAX_DAILY_LOSS=100        # Stop after modest loss
+MAX_DRAWDOWN_PCT=20       # Auto-stop at 20% drawdown
+```
+
+### Paper Trading First
+Always test strategies in paper trading mode before going live:
+```bash
+python -m probablyprofit.main --paper "your strategy"
+```
+
+## Incident Response
+
+### If You Suspect Compromise
+1. **Immediately** activate the kill switch
+2. Rotate ALL API keys
+3. Transfer funds to a new wallet
+4. Review logs for unauthorized access
+5. Check for unauthorized trades
+
+### Emergency Contacts
+- Polymarket support: [support@polymarket.com]
+- AI provider security: Check their security documentation
+
+## Security Checklist
+
+Before going live:
+- [ ] `.env` file is NOT in version control
+- [ ] `.env` file has restrictive permissions (600)
+- [ ] Using dedicated wallet (not main wallet)
+- [ ] API keys have usage limits set
+- [ ] Risk limits are configured conservatively
+- [ ] Kill switch is tested and working
+- [ ] Logs don't contain secrets
+- [ ] Running as non-root user
+- [ ] Paper trading tested successfully

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,150 @@
+# Troubleshooting Guide
+
+Common issues and their solutions when using ProbablyProfit.
+
+## Installation Issues
+
+### "Package requires Python >=3.10"
+**Problem:** Your Python version is too old.
+**Solution:** Install Python 3.10 or newer:
+```bash
+# macOS
+brew install python@3.11
+
+# Ubuntu/Debian
+sudo apt install python3.11
+```
+
+### Missing Dependencies
+**Problem:** Import errors for optional packages like `websockets` or `aiosqlite`.
+**Solution:** Install the required extras:
+```bash
+# Full install (recommended)
+pip install probablyprofit[full]
+
+# Or specific extras
+pip install probablyprofit[polymarket,db]
+```
+
+## Configuration Issues
+
+### "No AI providers configured"
+**Problem:** No API keys are set for AI providers.
+**Solution:** Set at least one API key in your `.env` file:
+```bash
+# Choose one or more:
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+GOOGLE_API_KEY=...
+```
+
+### "Kill switch is ACTIVE"
+**Problem:** The trading bot is blocked by the kill switch.
+**Solution:** The kill switch can be activated by:
+1. A file at `/tmp/probablyprofit.stop`
+2. Maximum drawdown being exceeded
+3. Manual activation via API
+
+To deactivate:
+```bash
+# Remove the file
+rm /tmp/probablyprofit.stop
+
+# Or via API
+curl -X POST http://localhost:8000/api/emergency-stop/deactivate
+```
+
+### "Private key not configured"
+**Problem:** Wallet private key is missing for live/paper trading.
+**Solution:** Add your Polygon wallet private key to `.env`:
+```bash
+PRIVATE_KEY=0x...your_private_key_here...
+```
+**Security:** Never commit this file to git!
+
+## Runtime Issues
+
+### API Rate Limits
+**Problem:** "Rate limit exceeded" errors from AI providers or Polymarket.
+**Solution:** Increase the loop interval in your config:
+```bash
+LOOP_INTERVAL=120  # Wait 2 minutes between iterations
+```
+
+### WebSocket Connection Failed
+**Problem:** "websockets package not installed" warning.
+**Solution:** Install websockets:
+```bash
+pip install websockets>=12.0
+```
+
+### Database Errors
+**Problem:** "no such table" or database connection errors.
+**Solution:** Initialize the database:
+```bash
+# Run migrations
+alembic upgrade head
+```
+
+### "Balance is 0" on Testnet
+**Problem:** No funds for paper trading.
+**Solution:** Paper trading uses simulated funds. For live trading on testnet, you need test USDC. Get some from the Polymarket faucet.
+
+## Trading Issues
+
+### Orders Not Executing
+**Problem:** Agent shows "DRY RUN" but you want real trades.
+**Solution:** Remove the `--dry-run` flag or set:
+```bash
+DRY_RUN=false
+```
+Then confirm with `--confirm-live` flag.
+
+### Position Size Too Small
+**Problem:** "Position size below minimum" rejection.
+**Solution:** The minimum order size on Polymarket is typically $1. Check your `MAX_POSITION_SIZE` config.
+
+### Risk Limits Rejecting Trades
+**Problem:** Agent keeps saying "Risk check failed".
+**Solution:** Review your risk limits in `.env`:
+```bash
+MAX_POSITION_SIZE=100     # Maximum per trade
+MAX_TOTAL_EXPOSURE=1000   # Maximum total portfolio
+MAX_DAILY_LOSS=200        # Daily loss limit
+```
+
+## Debugging Tips
+
+### Enable Debug Logging
+```bash
+LOG_LEVEL=DEBUG python -m probablyprofit.main ...
+```
+
+### Check Agent Status
+```bash
+curl http://localhost:8000/api/status
+```
+
+### View Recent Logs
+Logs are written via `loguru` to stderr. For file logging:
+```python
+from loguru import logger
+logger.add("probablyprofit.log", rotation="1 day")
+```
+
+### Inspect the Database
+```bash
+sqlite3 probablyprofit.db
+sqlite> .tables
+sqlite> SELECT * FROM trades ORDER BY timestamp DESC LIMIT 10;
+```
+
+## Getting Help
+
+If you're still stuck:
+1. Check the [GitHub Issues](https://github.com/randomness11/probablyprofit/issues)
+2. Open a new issue with:
+   - Your Python version (`python --version`)
+   - Your OS
+   - The full error message
+   - Relevant config (redact secrets!)

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Save, Key, Shield, Bell, Palette, RefreshCw } from 'lucide-react';
+import { useState } from 'react';
+import { Key, Shield, Bell, Palette } from 'lucide-react';
 import { useAgentControl } from '../hooks/useApi';
 
 interface SettingsSection {
@@ -17,7 +17,6 @@ const sections: SettingsSection[] = [
 
 export function Settings() {
   const [activeSection, setActiveSection] = useState('api');
-  const [saved, setSaved] = useState(false);
   const { setDryRun, loading } = useAgentControl();
 
   // Local state for settings
@@ -49,11 +48,8 @@ export function Settings() {
     showPnlPercent: true,
   });
 
-  const handleSave = () => {
-    // In a real app, this would save to backend
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-  };
+  // Note: Settings are read-only in the UI. Edit your .env file to change configuration.
+  // Backend settings API is planned for a future release.
 
   const updateSetting = <K extends keyof typeof settings>(
     key: K,
@@ -399,28 +395,15 @@ export function Settings() {
             </div>
           )}
 
-          {/* Save Button */}
-          <div className="mt-8 pt-6 border-t border-slate-700 flex justify-end">
-            <button
-              onClick={handleSave}
-              className={`flex items-center gap-2 px-6 py-2 rounded-lg font-medium transition-colors ${
-                saved
-                  ? 'bg-green-500 text-white'
-                  : 'bg-purple-500 hover:bg-purple-600 text-white'
-              }`}
-            >
-              {saved ? (
-                <>
-                  <RefreshCw className="w-4 h-4" />
-                  Saved!
-                </>
-              ) : (
-                <>
-                  <Save className="w-4 h-4" />
-                  Save Changes
-                </>
-              )}
-            </button>
+          {/* Configuration Notice */}
+          <div className="mt-8 pt-6 border-t border-slate-700">
+            <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+              <p className="text-sm text-slate-400">
+                <span className="font-medium text-slate-300">Note:</span> These settings are for reference only.
+                To change configuration, edit your <code className="bg-slate-900 px-1 rounded">.env</code> file
+                and restart the application.
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/probablyprofit/sources/trends.py
+++ b/probablyprofit/sources/trends.py
@@ -162,6 +162,7 @@ class GoogleTrendsClient:
                 return trend_data
 
             # If API fails, return neutral data
+            logger.warning(f"Google Trends API unavailable for '{keyword}', using neutral fallback data")
             return TrendData(
                 keyword=keyword,
                 current_interest=50,

--- a/probablyprofit/tests/test_agent_comprehensive.py
+++ b/probablyprofit/tests/test_agent_comprehensive.py
@@ -375,6 +375,8 @@ class TestAgentLoop:
         assert call_count[0] >= 3
 
     @pytest.mark.asyncio
+    @pytest.mark.slow  # This test takes ~35s due to real exponential backoff
+    @pytest.mark.timeout(45)  # Allow time for exponential backoff (5s + 10s + 20s)
     async def test_max_consecutive_errors_stops_loop(self, mock_agent, mock_client):
         """Test that too many consecutive errors stops the loop."""
         error_count = [0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,19 @@ disallow_untyped_defs = true
 exclude_dirs = ["tests", "venv", ".venv", "build", "dist"]
 skips = ["B101", "B104"]  # Skip assert warnings (B101) and hardcoded binding (B104)
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["probablyprofit/tests"]
+timeout = 30
+markers = [
+    "slow: marks tests as slow (run with --run-slow)",
+    "integration: integration tests requiring external services",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning:websockets.*",
+    "ignore::pydantic.PydanticDeprecatedSince20",
+]
+
 [tool.ruff.lint]
 select = [
     "E",    # pycodestyle errors


### PR DESCRIPTION
## Summary
- Remove `continue-on-error` from CI - tests now fail honestly
- Add pytest config with `slow`/`integration` markers
- Mark exponential backoff test as slow (takes ~35s)
- Remove fake save button from Settings page, add .env guidance
- Add warning log when Google Trends falls back to neutral data
- Add `docs/TROUBLESHOOTING.md` with common issues
- Add `docs/SECURITY.md` with best practices

## Test plan
- [ ] Run `pytest probablyprofit/tests/ -m "not slow"` - all 370 tests pass
- [ ] Check Settings page shows "edit .env" notice instead of save button
- [ ] Verify new docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)